### PR TITLE
removed extra curly braces in likeNote function

### DIFF
--- a/client/src/components/DocGrid/DocGrid.jsx
+++ b/client/src/components/DocGrid/DocGrid.jsx
@@ -55,7 +55,7 @@ const DocGrid = () => {
 
   useEffect(() => {
     fetchNotes();
-  }, []);
+  }, [open]);
 
   if (loading) {
     return <Loader />;

--- a/client/src/components/LikeButton/LikeButton.jsx
+++ b/client/src/components/LikeButton/LikeButton.jsx
@@ -38,9 +38,9 @@ const LikeButton = ({ noteId }) => {
         },
         withCredentials: true,
       };
-      await axios.get(`${import.meta.env.VITE_BASE_URL}/note/like/${noteId}`, {
+      await axios.get(`${import.meta.env.VITE_BASE_URL}/note/like/${noteId}`, 
         config,
-      });
+      );
 
       setIsLiked(true);
     } catch (error) {


### PR DESCRIPTION
On the notes page, the Like button was not functioning due to extra curly braces. After removing them, the code is now working perfectly.