### PR TITLE
fixed  : Bring the eye icons in the confirm password field #143

### DIFF
--- a/client/src/components/Signup/Signup.jsx
+++ b/client/src/components/Signup/Signup.jsx
@@ -97,6 +97,7 @@ const Signup = () => {
     errors?.confirm_password,
   ]);
   const navigate = useNavigate();
+  const [confirmPassToggle, setconfirmPassToggle] = useState("password");
 
   const [registerError, setRegisterError] = useState();
   const [passToggle, setPassToggle] = useState("password");
@@ -155,6 +156,13 @@ const Signup = () => {
       setLoading(false);
     }
   };
+  const toggleConfirmPassword=()=>{
+    if (confirmPassToggle === "password") {
+      setconfirmPassToggle("text");
+    } else {
+      setconfirmPassToggle("password");
+    }
+  }
 
   const togglePassword = () => {
     if (passToggle === "password") {
@@ -330,7 +338,7 @@ const Signup = () => {
                 <input
                   id="confirm_password"
                   name="confirm_password"
-                  type={passToggle}
+                  type={confirmPassToggle}
                   autoComplete="current-password"
                   className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
                   {...register("confirm_password", {
@@ -342,6 +350,17 @@ const Signup = () => {
                     },
                   })}
                 />
+                 <button
+                  type="button"
+                  onClick={toggleConfirmPassword}
+                  className="absolute inset-y-0 right-0 pr-3 flex items-center text-sm leading-5"
+                >
+                  {confirmPassToggle === "text" ? (
+                    <GoEyeClosed className="text-lg" />
+                  ) : (
+                    <GoEye className="text-lg" />
+                  )}
+                </button>
               </div>
             </div>
 


### PR DESCRIPTION
## Description

I placed the eye icon in the confirm field that is performing the  function like password field so that user can toggle the eye icon in the confirm field to hide and view the password

## Resolves: #143 

## Checklist

> Before submitting this pull request, kindly verify that the ensuing checkpoints have been reached.

- [ ] Have you adhered to the repository's defined coding convention rules?
- [ ] Have you updated the 'documentation.md' file with the method/function documentation?
- [ ] Have you sent a message along with the result or response?
- [ ] Have you used the try-catch technique?
- [ ] Has the method/class been added to the documentation (md file)?

## Screenshots

![Screenshot 2024-05-14 182443](https://github.com/hereisSwapnil/ExamTime/assets/118350936/094cd592-0fd6-43d4-a29d-3947855d3d8e)

![Screenshot 2024-05-14 182429](https://github.com/hereisSwapnil/ExamTime/assets/118350936/399b4cd7-63d7-4e5c-84cf-e629245334d4)



